### PR TITLE
thread クラス名の修正

### DIFF
--- a/script/const.js
+++ b/script/const.js
@@ -1,5 +1,5 @@
 const CLASS_OBJ = {
-  thread: 'z38b6 CnDs7d hPqowe',
+  thread: 'z38b6',
   messages: 'oIy2qc'
 }
 const INPUT_AREA = 'textarea[name="chatTextInput"]'


### PR DESCRIPTION
## 概要

拡張機能の公開ありがとうございます！

こちらを見つけてとてもおもしろい拡張機能だと思い利用してみたのですが、
リポジトリの develop を利用したら現在の meet で動かないようでした。

現在の meet で動くようにこの PR の変更をして、動くようになったことを確認いたしました。
ご検討いただけるとうれしいです。

## やったこと

### thread クラス名の修正 d92fa55

クラス名 `z38b6` がメッセージ一覧部分のタグに指定されているようだったので thread クラス名として利用するようにしました。

既存のクラス名 `CnDs7d`, `hPqowe` は現在の meet 画面では確認できなかったため削除しました。（スタイル定義は残っているようだったが、タグに指定はされていなかった。）

## 確認したこと

- 確認環境
  - chrome: 93.0.4577.82

この変更を含んだ拡張機能を読み込んだ状態で meet を開き、README の Usage 部分通りに操作してコメントが画面上に流れてきたこと。

変更前だと Usage 通りに操作してもコメントが画面上に流れてこなかったこと。
