### PR TITLE
fix typo

### DIFF
--- a/script/script.js
+++ b/script/script.js
@@ -1,6 +1,6 @@
 // NOTE: elements
 let prevThread;
-let isActive = localStorage.getItem('mns-active') === 'true'
+let isActive = localStorage.getItem('nsm-active') === 'true'
 
 let observer = new MutationObserver( (records) => {
   try {


### PR DESCRIPTION
表題の通り
nsm-active => niconico style for meet
mns-active => meet for niconico style
の表記ゆれの修正